### PR TITLE
Make dependencies installable from pip install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 python:
   - '2.7'
 install:
-  - pip install -r requirements.txt
+  - pip install -e .
   - pip install coveralls
   - pip install coverage
   - cp tests/testrail.conf ~/.testrail.conf

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-requests>=2.6.0
-singledispatch>=3.4.0
-pyyaml>=3.1.1

--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
     ],
+    install_requires=[
+        'requests>=2.6.0',
+        'singledispatch>=3.4.0',
+        'pyyaml>=3.1.1',
+    ],
 )


### PR DESCRIPTION
 - pip will not work with or install dependencies defined in requirements.txt.
   As such, this package cannot be run when installed through pip/PyPI, as the
   three dependencies don't get installed.
 - Move dependencies to setup.py file
 - Remove requirements.txt
 - Update travis.yml to install without requirements.txt