### PR TITLE
Feature create runs

### DIFF
--- a/testrail/api.py
+++ b/testrail/api.py
@@ -7,7 +7,7 @@ import os
 import requests
 import yaml
 
-from testrail.helper import TestRailError, UpdateCache
+from testrail.helper import TestRailError
 
 nested_dict = lambda: collections.defaultdict(nested_dict)
 
@@ -179,20 +179,17 @@ class API(object):
                 raise TestRailError(
                     "Milestone ID '%s' was not found" % milestone_id)
 
-    @UpdateCache(_shared_state['_milestones'])
     def add_milestone(self, milestone):
         fields = ['name', 'description', 'due_on']
         project_id = milestone.get('project_id')
         payload = self._payload_gen(fields, milestone)
         return self._post('add_milestone/%s' % project_id, payload)
 
-    @UpdateCache(_shared_state['_milestones'])
     def update_milestone(self, milestone):
         fields = ['name', 'description', 'due_on', 'is_completed']
         data = self._payload_gen(fields, milestone)
         return self._post('update_milestone/%s' % milestone.get('id'), data)
 
-    @UpdateCache(_shared_state['_milestones'])
     def delete_milestone(self, milestone_id):
         return self._post('delete_milestone/%s' % milestone_id)
 
@@ -263,7 +260,6 @@ class API(object):
         except IndexError:
             raise TestRailError("Run ID '%s' was not found" % run_id)
 
-    @UpdateCache(_shared_state['_runs'])
     def add_run(self, run):
         fields = ['name', 'description', 'suite_id', 'milestone_id',
                   'assignedto_id', 'include_all', 'case_ids']
@@ -271,18 +267,15 @@ class API(object):
         payload = self._payload_gen(fields, run)
         return self._post('add_run/%s' % project_id, payload)
 
-    @UpdateCache(_shared_state['_runs'])
     def update_run(self, run):
         fields = [
             'name', 'description', 'milestone_id', 'include_all', 'case_ids']
         data = self._payload_gen(fields, run)
         return self._post('update_run/%s' % run.get('id'), data)
 
-    @UpdateCache(_shared_state['_runs'])
     def close_run(self, run_id):
         return self._post('close_run/%s' % run_id)
 
-    @UpdateCache(_shared_state['_runs'])
     def delete_run(self, run_id):
         return self._post('delete_run/%s' % run_id)
 

--- a/testrail/api.py
+++ b/testrail/api.py
@@ -257,6 +257,25 @@ class API(object):
         except IndexError:
             raise TestRailError("Run ID '%s' was not found" % run_id)
 
+    def add_run(self, run):
+        fields = ['name', 'description', 'suite_id', 'milestone_id',
+                  'assignedto_id', 'include_all', 'case_ids']
+        project_id = run.get('project_id')
+        payload = self._payload_gen(fields, run)
+        self._post('add_run/%s' % project_id, payload)
+
+    def update_run(self, run):
+        fields = [
+            'name', 'description', 'milestone_id', 'include_all', 'case_ids']
+        data = self._payload_gen(fields, run)
+        self._post('update_run/%s' % run.get('id'), data)
+
+    def close_run(self, run_id):
+        self._post('close_run/%s' % run_id)
+
+    def delete_run(self, run_id):
+        self._post('delete_run/%s' % run_id)
+
     # Test Requests
     def tests(self, run_id):
         if self._refresh(self._tests[run_id]['ts']):

--- a/testrail/client.py
+++ b/testrail/client.py
@@ -35,6 +35,10 @@ class TestRail(object):
         raise NotImplementedError
 
     @methdispatch
+    def close(self, obj):
+        raise NotImplementedError
+
+    @methdispatch
     def delete(self, obj):
         raise NotImplementedError
 
@@ -192,6 +196,23 @@ class TestRail(object):
     @singleresult
     def _run_by_id(self, run_id):
         filter(lambda p: p.id == run_id, self.runs())
+
+    @add.register(Run)
+    def _add_run(self, obj):
+        obj.project = obj.project or self.project(self._project_id)
+        self.api.add_run(obj.raw_data())
+
+    @update.register(Run)
+    def _update_run(self, obj):
+        self.api.update_run(obj.raw_data())
+
+    @close.register(Run)
+    def _close_run(self, obj):
+        self.api.close_run(obj.id)
+
+    @delete.register(Run)
+    def _delete_run(self, obj):
+        self.api.delete_run(obj.id)
 
     # Case Methods
     def cases(self, suite):

--- a/testrail/client.py
+++ b/testrail/client.py
@@ -148,7 +148,7 @@ class TestRail(object):
 
     @delete.register(Milestone)
     def _delete_milestone(self, obj):
-        return Milestone(self.api.delete_milestone(obj.id))
+        return self.api.delete_milestone(obj.id)
 
     # Plan Methods
     @methdispatch

--- a/testrail/client.py
+++ b/testrail/client.py
@@ -8,7 +8,7 @@ from testrail.milestone import Milestone
 from testrail.plan import Plan, PlanContainer
 from testrail.project import Project, ProjectContainer
 from testrail.result import Result
-from testrail.run import Run, RunContainer, Active, Closed
+from testrail.run import Run, RunContainer
 from testrail.status import Status
 from testrail.suite import Suite
 from testrail.test import Test
@@ -41,13 +41,6 @@ class TestRail(object):
     @methdispatch
     def delete(self, obj):
         raise NotImplementedError
-
-    # Active/Closed Methods
-    def active(self):
-        return Active()
-
-    def closed(self):
-        return Closed()
 
     # Project Methods
     def projects(self):
@@ -189,16 +182,6 @@ class TestRail(object):
     def _runs_for_milestone(self, obj):
         return RunContainer(filter(
             lambda r: r.milestone.id == obj.id, self.runs()))
-
-    @runs.register(Active)
-    def _runs_for_active(self, obj):
-        return RunContainer(
-            list(map(Run, self.api.runs(self._project_id, completed=False))))
-
-    @runs.register(Closed)
-    def _runs_for_closed(self, obj):
-        return RunContainer(
-            list(map(Run, self.api.runs(self._project_id, completed=True))))
 
     @methdispatch
     def run(self):

--- a/testrail/helper.py
+++ b/testrail/helper.py
@@ -49,6 +49,9 @@ class ContainerIter(object):
     def __iter__(self):
         return self
 
+    def __len__(self):
+        return len(self._objs)
+
     def __next__(self):
         return self.__next()
 

--- a/testrail/helper.py
+++ b/testrail/helper.py
@@ -61,3 +61,19 @@ class ContainerIter(object):
 
     def next(self):
         return self.__next()
+
+
+class UpdateCache(object):
+    """ Decorator class for forcing cache to update by forcing the timestamp to
+        be None
+    """
+    def __init__(self, cache):
+        self.cache = cache
+
+    def __call__(self, f):
+        def wrapped_f(*args, **kwargs):
+            resp = f(*args, **kwargs)
+            if 'project_id' in resp:
+                self.cache[resp['project_id']]['ts'] = None
+            return resp
+        return wrapped_f

--- a/testrail/helper.py
+++ b/testrail/helper.py
@@ -64,19 +64,3 @@ class ContainerIter(object):
 
     def next(self):
         return self.__next()
-
-
-class UpdateCache(object):
-    """ Decorator class for forcing cache to update by forcing the timestamp to
-        be None
-    """
-    def __init__(self, cache):
-        self.cache = cache
-
-    def __call__(self, f):
-        def wrapped_f(*args, **kwargs):
-            resp = f(*args, **kwargs)
-            if 'project_id' in resp:
-                self.cache[resp['project_id']]['ts'] = None
-            return resp
-        return wrapped_f

--- a/testrail/run.py
+++ b/testrail/run.py
@@ -9,8 +9,8 @@ from testrail.user import User
 
 
 class Run(object):
-    def __init__(self, content):
-        self._content = content
+    def __init__(self, content=None):
+        self._content = content or dict()
         self.api = API()
 
     @property
@@ -85,13 +85,26 @@ class Run(object):
     def name(self):
         return self._content.get('name')
 
+    @name.setter
+    def name(self, value):
+        if type(value) != str:
+            raise TestRailError('input must be a string')
+        self._content['name'] = value
+
     @property
     def passed_count(self):
         return self._content.get('passed_count')
 
     @property
     def project(self):
-        return Project(self.api.project_with_id(self._content.get('id')))
+        return Project(self.api.project_with_id(self._content.get('project_id')))
+
+    @project.setter
+    def project(self, value):
+        if type(value) != Project:
+            raise TestRailError('input must be a Project')
+        self.api.project_with_id(value.id)  # verify project is valid
+        self._content['project_id'] = value.id
 
     @property
     def retest_count(self):
@@ -104,6 +117,9 @@ class Run(object):
     @property
     def url(self):
         return self._content.get('url')
+
+    def raw_data(self):
+        return self._content
 
 
 class RunContainer(ContainerIter):

--- a/testrail/run.py
+++ b/testrail/run.py
@@ -140,10 +140,3 @@ class RunContainer(ContainerIter):
 
     def active(self):
         return filter(lambda m: m.is_completed is False, self._runs)
-
-
-class Active(object):
-    pass
-
-class Closed(object):
-    pass

--- a/testrail/run.py
+++ b/testrail/run.py
@@ -140,3 +140,10 @@ class RunContainer(ContainerIter):
 
     def active(self):
         return filter(lambda m: m.is_completed is False, self._runs)
+
+
+class Active(object):
+    pass
+
+class Closed(object):
+    pass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,7 +6,7 @@ except ImportError:
 import mock
 
 from testrail.project import Project
-from testrail.run import RunContainer, Run, Active, Closed
+from testrail.run import RunContainer, Run
 import testrail
 
 
@@ -100,7 +100,7 @@ class TestProject(unittest.TestCase):
             assert isinstance(project, Project)
 
     @mock.patch('testrail.api.requests.get')
-    def test_get_runs(self, mock_get):
+    def test_get_runs_returns_runcontainer(self, mock_get):
         mock_response = mock.Mock()
         mock_response.json.return_value = self.mock_runs_data
         mock_response.status_code = 200
@@ -108,21 +108,50 @@ class TestProject(unittest.TestCase):
         runs = self.client.runs()
         assert isinstance(runs, RunContainer)
         self.assertEqual(len(runs), 2)
-        for run in runs:
-            assert isinstance(run, Run)
 
-        active_runs = list(runs.active())
+    @mock.patch('testrail.api.requests.get')
+    def test_runcontainer_contains_only_run_objects(self, mock_get):
+        mock_response = mock.Mock()
+        mock_response.json.return_value = self.mock_runs_data
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+        runs = self.client.runs()
+        self.assertTrue(all([isinstance(r, Run) for r in runs]))
+
+    @mock.patch('testrail.api.requests.get')
+    def test_runcontainer_active_runs(self, mock_get):
+        mock_response = mock.Mock()
+        mock_response.json.return_value = self.mock_runs_data
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+        active_runs = list(self.client.runs().active())
         self.assertEqual(len(active_runs), 1)
         self.assertEqual(active_runs[0].id, 111)
 
-        completed_runs = list(runs.completed())
+    @mock.patch('testrail.api.requests.get')
+    def test_runcontainer_completed_runs(self, mock_get):
+        mock_response = mock.Mock()
+        mock_response.json.return_value = self.mock_runs_data
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+        completed_runs = list(self.client.runs().completed())
         self.assertEqual(len(completed_runs), 1)
         self.assertEqual(completed_runs[0].id, 222)
 
-        latest_run = runs.latest()
-        assert isinstance(latest_run, Run)
+    @mock.patch('testrail.api.requests.get')
+    def test_runcontainer_latest_runs(self, mock_get):
+        mock_response = mock.Mock()
+        mock_response.json.return_value = self.mock_runs_data
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+        latest_run = self.client.runs().latest()
         self.assertEqual(latest_run.id, 222)
 
-        oldest_run = runs.oldest()
-        assert isinstance(oldest_run, Run)
+    @mock.patch('testrail.api.requests.get')
+    def test_runcontainer_oldest_runs(self, mock_get):
+        mock_response = mock.Mock()
+        mock_response.json.return_value = self.mock_runs_data
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+        oldest_run = self.client.runs().oldest()
         self.assertEqual(oldest_run.id, 111)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,6 +6,7 @@ except ImportError:
 import mock
 
 from testrail.project import Project
+from testrail.run import RunContainer, Run, Active, Closed
 import testrail
 
 
@@ -33,6 +34,57 @@ class TestProject(unittest.TestCase):
             }
         ]
 
+        self.mock_runs_data = [
+	    {
+                'assignedto_id': None,
+                'blocked_count': 0,
+                'completed_on': None,
+                'config': None,
+                'config_ids': [],
+                'created_by': 2,
+                'created_on': 1457761236,
+                'custom_status1_count': 0,
+                'description': None,
+                'failed_count': 0,
+                'id': 111,
+                'include_all': True,
+                'is_completed': False,
+                'milestone_id': None,
+                'name': 'Test Run Mock',
+                'passed_count': 0,
+                'plan_id': None,
+                'project_id': 1,
+                'retest_count': 0,
+                'suite_id': 1,
+                'untested_count': 3,
+                'url': 'https://<server>/index.php?/runs/view/111'
+            },
+	    {
+                'assignedto_id': None,
+                'blocked_count': 0,
+                'completed_on': None,
+                'config': None,
+                'config_ids': [],
+                'created_by': 2,
+                'created_on': 1457761237,
+                'custom_status1_count': 0,
+                'description': None,
+                'failed_count': 0,
+                'id': 222,
+                'include_all': True,
+                'is_completed': True,
+                'milestone_id': None,
+                'name': 'Test Run Mock',
+                'passed_count': 0,
+                'plan_id': None,
+                'project_id': 1,
+                'retest_count': 0,
+                'suite_id': 1,
+                'untested_count': 3,
+                'url': 'https://<server>/index.php?/runs/view/222'
+            },
+        ]
+
     def tearDown(self):
             pass
 
@@ -46,3 +98,31 @@ class TestProject(unittest.TestCase):
         self.assertEqual(len(projects), 2)
         for project in projects:
             assert isinstance(project, Project)
+
+    @mock.patch('testrail.api.requests.get')
+    def test_get_runs(self, mock_get):
+        mock_response = mock.Mock()
+        mock_response.json.return_value = self.mock_runs_data
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+        runs = self.client.runs()
+        assert isinstance(runs, RunContainer)
+        self.assertEqual(len(runs), 2)
+        for run in runs:
+            assert isinstance(run, Run)
+
+        active_runs = list(runs.active())
+        self.assertEqual(len(active_runs), 1)
+        self.assertEqual(active_runs[0].id, 111)
+
+        completed_runs = list(runs.completed())
+        self.assertEqual(len(completed_runs), 1)
+        self.assertEqual(completed_runs[0].id, 222)
+
+        latest_run = runs.latest()
+        assert isinstance(latest_run, Run)
+        self.assertEqual(latest_run.id, 222)
+
+        oldest_run = runs.oldest()
+        assert isinstance(oldest_run, Run)
+        self.assertEqual(oldest_run.id, 111)


### PR DESCRIPTION
- closes #24 (Adds run creation support)
- closes #4 (Found instance where `id` was being used instead of `project_id`)
- Adds test run related support, including creating, updating, closing, and deleting runs
- Add cache updating logic to clear the cache if an item has been added to, deleted from, or updated in the cache.