### PR TITLE
Feature cache updating

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ install_requires=[
     'requests>=2.6.0',
     'singledispatch>=3.4.0',
     'pyyaml>=3.1.1',
+    'future',
 ]
 
 if sys.version_info[:3] < (2, 7, 0):

--- a/testrail/api.py
+++ b/testrail/api.py
@@ -58,6 +58,10 @@ class UpdateCache(object):
         '''
         project_id = update_obj['project_id']
 
+        if not self.cache[project_id]['ts']:
+            # The cache will clear on the next read, so no reason to add/update
+            return
+
         obj_list = self.cache[project_id]['value']
         for index, obj in enumerate(obj_list):
             if obj['id'] == update_obj['id']:

--- a/testrail/run.py
+++ b/testrail/run.py
@@ -107,6 +107,10 @@ class Run(object):
         self._content['project_id'] = value.id
 
     @property
+    def project_id(self):
+        return self._content.get('project_id')
+
+    @property
     def retest_count(self):
         return self._content.get('retest_count')
 

--- a/tests/test_updatecache.py
+++ b/tests/test_updatecache.py
@@ -55,6 +55,21 @@ class TestUpdateCache(unittest.TestCase):
         self.assertEqual(len(add_cache[1]['value']), 6)
         self.assertEqual(add_cache[1]['value'][-1], add_obj)
 
+    def test_cache_add_when_no_timestamp(self,):
+        no_ts_cache = deepcopy(self.mock_cache)
+        no_ts_cache[1]['ts'] = None
+        no_ts_obj = {'id': 'id11', 'val': 'test_cache_update', 'project_id': 1}
+ 
+        @UpdateCache(no_ts_cache)
+        def cache_update_func():
+            return no_ts_obj
+
+        cache_update_func()
+
+        self.assertEqual(len(no_ts_cache[0]['value']), 5)
+        self.assertEqual(len(no_ts_cache[1]['value']), 5)
+        self.assertEqual(no_ts_cache[1]['value'][1]['val'], 'oldval')
+
     def test_cache_update(self,):
         update_cache = deepcopy(self.mock_cache)
         update_obj = {'id': 'id12', 'val': 'test_cache_update', 'project_id': 1}
@@ -68,6 +83,20 @@ class TestUpdateCache(unittest.TestCase):
         self.assertEqual(len(update_cache[0]['value']), 5)
         self.assertEqual(len(update_cache[1]['value']), 5)
         self.assertEqual(update_cache[1]['value'][2], update_obj)
+
+    def test_cache_update_when_no_timestamp(self,):
+        no_ts_cache = deepcopy(self.mock_cache)
+        no_ts_cache[1]['ts'] = None
+        no_ts_obj = {'id': 'id15', 'val': 'test_cache_update', 'project_id': 1}
+ 
+        @UpdateCache(no_ts_cache)
+        def cache_update_func():
+            return no_ts_obj
+
+        cache_update_func()
+
+        self.assertEqual(len(no_ts_cache[0]['value']), 5)
+        self.assertEqual(len(no_ts_cache[1]['value']), 5)
 
     def test_cache_delete(self,):
         delete_cache = deepcopy(self.mock_cache)

--- a/tests/test_updatecache.py
+++ b/tests/test_updatecache.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from builtins import dict
+from datetime import datetime as dt
 
 try:
     import unittest2 as unittest
@@ -16,6 +17,7 @@ class TestUpdateCache(unittest.TestCase):
     def setUp(self):
         self.mock_cache = {
             0: {
+                'ts': dt.now(),
                 'value': [
                     {'id': 'id00', 'val': 'oldval'},
                     {'id': 'id01', 'val': 'oldval'},
@@ -25,6 +27,7 @@ class TestUpdateCache(unittest.TestCase):
                 ]
             },
             1: {
+                'ts': dt.now(),
                 'value': [
                     {'id': 'id10', 'val': 'oldval'},
                     {'id': 'id11', 'val': 'oldval'},
@@ -83,21 +86,17 @@ class TestUpdateCache(unittest.TestCase):
             for obj in project['value']:
                 self.assertNotEqual(id_to_delete, obj['id'])
 
-    def test_cache_raises_error(self,):
-        raise_cache = deepcopy(self.mock_cache)
-        raise_obj = {}
+    def test_cache_refresh(self,):
+        refresh_cache = deepcopy(self.mock_cache)
+        force_refresh_obj = {}
         id_to_delete = 'id23'
  
-        @UpdateCache(raise_cache)
-        def cache_raise_func(val):
-            return raise_obj
+        @UpdateCache(refresh_cache)
+        def cache_refresh_func(val):
+            return force_refresh_obj
 
-        with self.assertRaises(TestRailError) as e:
-            cache_raise_func(id_to_delete)
+        cache_refresh_func(id_to_delete)
 
-        self.assertEqual(len(raise_cache[0]['value']), 5)
-        self.assertEqual(len(raise_cache[1]['value']), 5)
-        exp_exc_str = "could not locate item with id {0}".format(id_to_delete)
-        self.assertIn(exp_exc_str, str(e.exception))
-
-
+        self.assertEqual(len(refresh_cache[0]['value']), 5)
+        self.assertEqual(len(refresh_cache[1]['value']), 5)
+        self.assertTrue(all([x['ts'] is None for x in refresh_cache.values()]))

--- a/tests/test_updatecache.py
+++ b/tests/test_updatecache.py
@@ -1,0 +1,103 @@
+from copy import deepcopy
+from builtins import dict
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import mock
+
+from testrail.api import UpdateCache
+from testrail.helper import TestRailError
+
+
+class TestUpdateCache(unittest.TestCase):
+    def setUp(self):
+        self.mock_cache = {
+            0: {
+                'value': [
+                    {'id': 'id00', 'val': 'oldval'},
+                    {'id': 'id01', 'val': 'oldval'},
+                    {'id': 'id02', 'val': 'oldval'},
+                    {'id': 'id03', 'val': 'oldval'},
+                    {'id': 'id04', 'val': 'oldval'}
+                ]
+            },
+            1: {
+                'value': [
+                    {'id': 'id10', 'val': 'oldval'},
+                    {'id': 'id11', 'val': 'oldval'},
+                    {'id': 'id12', 'val': 'oldval'},
+                    {'id': 'id13', 'val': 'oldval'},
+                    {'id': 'id14', 'val': 'oldval'}
+                ]
+            }
+        }
+
+    def tearDown(self):
+            pass
+
+    def test_cache_add(self,):
+        add_cache = deepcopy(self.mock_cache)
+        add_obj = {'id': 'id15', 'val': 'test_cache_add', 'project_id': 1}
+ 
+        @UpdateCache(add_cache)
+        def cache_add_func():
+            return add_obj
+
+        cache_add_func()
+
+        self.assertEqual(len(add_cache[0]['value']), 5)
+        self.assertEqual(len(add_cache[1]['value']), 6)
+        self.assertEqual(add_cache[1]['value'][-1], add_obj)
+
+    def test_cache_update(self,):
+        update_cache = deepcopy(self.mock_cache)
+        update_obj = {'id': 'id12', 'val': 'test_cache_update', 'project_id': 1}
+ 
+        @UpdateCache(update_cache)
+        def cache_update_func():
+            return update_obj
+
+        cache_update_func()
+
+        self.assertEqual(len(update_cache[0]['value']), 5)
+        self.assertEqual(len(update_cache[1]['value']), 5)
+        self.assertEqual(update_cache[1]['value'][2], update_obj)
+
+    def test_cache_delete(self,):
+        delete_cache = deepcopy(self.mock_cache)
+        delete_obj = {}
+        id_to_delete = 'id13'
+ 
+        @UpdateCache(delete_cache)
+        def cache_delete_func(val):
+            return delete_obj
+
+        cache_delete_func(id_to_delete)
+
+        self.assertEqual(len(delete_cache[0]['value']), 5)
+        self.assertEqual(len(delete_cache[1]['value']), 4)
+        for project in delete_cache.values():
+            for obj in project['value']:
+                self.assertNotEqual(id_to_delete, obj['id'])
+
+    def test_cache_raises_error(self,):
+        raise_cache = deepcopy(self.mock_cache)
+        raise_obj = {}
+        id_to_delete = 'id23'
+ 
+        @UpdateCache(raise_cache)
+        def cache_raise_func(val):
+            return raise_obj
+
+        with self.assertRaises(TestRailError) as e:
+            cache_raise_func(id_to_delete)
+
+        self.assertEqual(len(raise_cache[0]['value']), 5)
+        self.assertEqual(len(raise_cache[1]['value']), 5)
+        exp_exc_str = "could not locate item with id {0}".format(id_to_delete)
+        self.assertIn(exp_exc_str, str(e.exception))
+
+


### PR DESCRIPTION
 - closes #8 
 - Add cache updating decorator
 - Add tests for cache updating decorator

The UpdateCache class is pretty specific to the cache structure for the API class, so I added it to the `api.py` file rather than the `helper` file. Let me know if you would like it to live in a different place.