### PR TITLE
Add base class to for better __str__ and __repr__ logging

### DIFF
--- a/testrail/base.py
+++ b/testrail/base.py
@@ -1,0 +1,9 @@
+class TestRailBase(object):
+    """ Base class for all TestRail objects with a TestRail ID
+    """
+    def __str__(self):
+        class_name = self.__class__.__name__
+        return "{0}-{1}".format(class_name, self.id)
+
+    def __repr__(self):
+        return str(self)

--- a/testrail/case.py
+++ b/testrail/case.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from testrail.base import TestRailBase
 from testrail.api import API
 from testrail.casetype import CaseType
 from testrail.helper import custom_methods
@@ -10,7 +11,7 @@ from testrail.suite import Suite
 from testrail.user import User
 
 
-class Case(object):
+class Case(TestRailBase):
     def __init__(self, content):
         self._content = content
         self.api = API()

--- a/testrail/casetype.py
+++ b/testrail/casetype.py
@@ -1,4 +1,7 @@
-class CaseType(object):
+from testrail.base import TestRailBase
+
+
+class CaseType(TestRailBase):
     def __init__(self, content):
         self._content = content
 

--- a/testrail/configuration.py
+++ b/testrail/configuration.py
@@ -1,8 +1,9 @@
+from testrail.base import TestRailBase
 from testrail.helper import ContainerIter, methdispatch, singleresult
 from testrail.project import Project
 
 
-class _InnerConfig(object):
+class _InnerConfig(TestRailBase):
     def __init__(self, content=None):
         self._content = content or dict()
 
@@ -19,7 +20,7 @@ class _InnerConfig(object):
         return self._content.get('name')
 
 
-class Config(object):
+class Config(TestRailBase):
     def __init__(self, content=None):
         self._content = content or dict()
 

--- a/testrail/entry.py
+++ b/testrail/entry.py
@@ -1,3 +1,4 @@
+from testrail.base import TestRailBase
 from testrail.api import API
 from testrail.run import Run
 from testrail.suite import Suite
@@ -16,7 +17,7 @@ class EntryRun(Run):
         return self._content.get('entry_index')
 
 
-class Entry(object):
+class Entry(TestRailBase):
     def __init__(self, content):
         self._content = content
         self._api = API()

--- a/testrail/milestone.py
+++ b/testrail/milestone.py
@@ -1,12 +1,13 @@
 from datetime import datetime
 import time
 
+from testrail.base import TestRailBase
 from testrail import api
 from testrail.project import Project
 from testrail.helper import TestRailError
 
 
-class Milestone(object):
+class Milestone(TestRailBase):
     def __init__(self, content=None):
         self._content = content or dict()
         self.api = api.API()

--- a/testrail/plan.py
+++ b/testrail/plan.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from testrail.base import TestRailBase
 import testrail.entry
 from testrail.api import API
 from testrail.user import User
@@ -8,7 +9,7 @@ from testrail.milestone import Milestone
 from testrail.helper import ContainerIter, TestRailError
 
 
-class Plan(object):
+class Plan(TestRailBase):
     def __init__(self, content=None):
         self._content = content or dict()
         self.api = API()

--- a/testrail/priority.py
+++ b/testrail/priority.py
@@ -1,4 +1,7 @@
-class Priority(object):
+from testrail.base import TestRailBase
+
+
+class Priority(TestRailBase):
     def __init__(self, content):
         self._content = content
 

--- a/testrail/project.py
+++ b/testrail/project.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 
+from testrail.base import TestRailBase
 from testrail.helper import ContainerIter, TestRailError
 
 
-class Project(object):
+class Project(TestRailBase):
     def __init__(self, response=None):
         self._content = response or dict()
 

--- a/testrail/result.py
+++ b/testrail/result.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 import re
 
+from testrail.base import TestRailBase
 from testrail import api
 from testrail.helper import ContainerIter, TestRailError
 from testrail.status import Status
@@ -9,7 +10,7 @@ from testrail.user import User
 from testrail.helper import testrail_duration_to_timedelta
 
 
-class Result(object):
+class Result(TestRailBase):
     def __init__(self, content=None):
         self._content = content or dict()
         self.api = api.API()

--- a/testrail/run.py
+++ b/testrail/run.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from testrail.base import TestRailBase
 from testrail.api import API
 from testrail.helper import ContainerIter, TestRailError
 from testrail.milestone import Milestone
@@ -10,7 +11,7 @@ from testrail.case import Case
 from testrail.helper import TestRailError
 
 
-class Run(object):
+class Run(TestRailBase):
     def __init__(self, content=None):
         self._content = content or dict()
         self.api = API()

--- a/testrail/section.py
+++ b/testrail/section.py
@@ -1,9 +1,10 @@
+from testrail.base import TestRailBase
 from testrail import api
 from testrail.helper import TestRailError
 from testrail.suite import Suite
 
 
-class Section(object):
+class Section(TestRailBase):
     def __init__(self, content):
         self._content = content
         self.api = api.API()

--- a/testrail/status.py
+++ b/testrail/status.py
@@ -1,4 +1,7 @@
-class Status(object):
+from testrail.base import TestRailBase
+
+
+class Status(TestRailBase):
     def __init__(self, content):
         self._content = content
 

--- a/testrail/suite.py
+++ b/testrail/suite.py
@@ -1,11 +1,12 @@
 from datetime import datetime
 
+from testrail.base import TestRailBase
 from testrail import api
 from testrail.helper import TestRailError
 from testrail.project import Project
 
 
-class Suite(object):
+class Suite(TestRailBase):
     def __init__(self, content=None):
         self._content = content or dict()
         self.api = api.API()

--- a/testrail/test.py
+++ b/testrail/test.py
@@ -1,3 +1,4 @@
+from testrail.base import TestRailBase
 from testrail import api
 from testrail.case import Case
 from testrail.casetype import CaseType
@@ -9,7 +10,7 @@ from testrail.user import User
 from testrail.helper import testrail_duration_to_timedelta
 
 
-class Test(object):
+class Test(TestRailBase):
     def __init__(self, content=None):
         self._content = content or dict()
         self.api = api.API()

--- a/testrail/user.py
+++ b/testrail/user.py
@@ -1,4 +1,7 @@
-class User(object):
+from testrail.base import TestRailBase
+
+
+class User(TestRailBase):
     def __init__(self, content=None):
         self._content = content or dict()
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,22 @@
+import mock
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from testrail.base import TestRailBase
+
+
+class TestBase(unittest.TestCase):
+    def setUp(self):
+        class Foo(TestRailBase):
+            def __init__(self, id):
+                self.id = id
+
+        self.base = Foo(123)
+
+    def test___str__(self):
+        self.assertEqual(str(self.base), "Foo-123")
+
+    def test___repr__(self):
+        self.assertEqual(repr(self.base), "Foo-123")


### PR DESCRIPTION
Closes #21 

Add a new base class for all TestRail objects with an `id`. The new class has `__str__` and `__repr__` methods that print out better identifying information to make debugging easier.

Before this change, this script:

```
from testrail import TestRail
tr = TestRail(11)
print(tr.runs().completed())
```

Would output something like this:
```
[
  <testrail.run.Run object at 0x10ea8bcf8>,
  <testrail.run.Run object at 0x10ea8ba58>,
  <testrail.run.Run object at 0x10ea8b630>,
  <testrail.run.Run object at 0x10ea8b438>,
  <testrail.run.Run object at 0x10ea8b588>,
  <testrail.run.Run object at 0x10ea8bc50>
  <...>
]
```

Which is difficult to debug. With this change, the same script above would produce output like this:
```
[
  Run-17196,
  Run-17195,
  Run-17194,
  Run-17060,
  Run-17056,
  Run-17054,
  <...>
]
```