### PR TITLE
Replace type checking method

### DIFF
--- a/testrail/milestone.py
+++ b/testrail/milestone.py
@@ -27,7 +27,7 @@ class Milestone(TestRailBase):
     @description.setter
     def description(self, value):
         if value is not None:
-            if type(value) != str:
+            if not isinstance(value, str):
                 raise TestRailError('input must be string or None')
         self._content['description'] = value
 
@@ -43,7 +43,7 @@ class Milestone(TestRailBase):
         if value is None:
             due = None
         else:
-            if type(value) != datetime:
+            if not isinstance(value, datetime):
                 raise TestRailError('input must be a datetime or None')
             due = int(time.mktime(value.timetuple()))
         self._content['due_on'] = due
@@ -58,7 +58,7 @@ class Milestone(TestRailBase):
 
     @is_completed.setter
     def is_completed(self, value):
-        if type(value) != bool:
+        if not isinstance(value, bool):
             raise TestRailError('input must be a boolean')
         self._content['is_completed'] = value
 
@@ -68,7 +68,7 @@ class Milestone(TestRailBase):
 
     @name.setter
     def name(self, value):
-        if type(value) != str:
+        if not isinstance(value, str):
             raise TestRailError('input must be a string')
         self._content['name'] = value
 
@@ -79,7 +79,7 @@ class Milestone(TestRailBase):
 
     @project.setter
     def project(self, value):
-        if type(value) != Project:
+        if not isinstance(value, Project):
             raise TestRailError('input must be a Project')
         self.api.project_with_id(value.id)  # verify project is valid
         self._content['project_id'] = value.id

--- a/testrail/plan.py
+++ b/testrail/plan.py
@@ -110,7 +110,7 @@ class Plan(TestRailBase):
 
     @project.setter
     def project(self, value):
-        if type(value) != Project:
+        if not isinstance(value, Project):
             raise TestRailError('input must be a Project')
         self.api.project_with_id(value.id)  # verify project is valid
         self._content['project_id'] = value.id

--- a/testrail/project.py
+++ b/testrail/project.py
@@ -15,7 +15,7 @@ class Project(TestRailBase):
 
     @announcement.setter
     def announcement(self, msg):
-        if type(msg) != str:
+        if not isinstance(msg, str):
             raise TestRailError('input must be a string')
         self._content['announcement'] = msg
 
@@ -38,7 +38,7 @@ class Project(TestRailBase):
 
     @is_completed.setter
     def is_completed(self, value):
-        if type(value) != bool:
+        if not isinstance(value, bool):
             raise TestRailError('input must be a boolean')
         self._content['is_completed'] = value
 
@@ -49,7 +49,7 @@ class Project(TestRailBase):
 
     @name.setter
     def name(self, value):
-        if type(value) != str:
+        if not isinstance(value, str):
             raise TestRailError('input must be a string')
         self._content['name'] = value
 
@@ -60,7 +60,7 @@ class Project(TestRailBase):
 
     @show_announcement.setter
     def show_announcement(self, value):
-        if type(value) != bool:
+        if not isinstance(value, bool):
             raise TestRailError('input must be a boolean')
         self._content['show_announcement'] = value
 
@@ -74,7 +74,7 @@ class Project(TestRailBase):
 
     @suite_mode.setter
     def suite_mode(self, mode):
-        if type(mode) != int:
+        if not isinstance(mode, int):
             raise TestRailError('input must be an integer')
         if mode not in [1, 2, 3]:
             raise TestRailError('input must be a 1, 2, or 3')

--- a/testrail/result.py
+++ b/testrail/result.py
@@ -22,7 +22,7 @@ class Result(TestRailBase):
 
     @assigned_to.setter
     def assigned_to(self, user):
-        if type(user) != User:
+        if not isinstance(user, User):
             raise TestRailError('input must be a User object')
         try:
             self.api.user_with_id(user.id)
@@ -36,7 +36,7 @@ class Result(TestRailBase):
 
     @comment.setter
     def comment(self, value):
-        if type(value) != str:
+        if not isinstance(value, str):
             raise TestRailError('input must be a string')
         self._content['comment'] = value
 
@@ -58,9 +58,9 @@ class Result(TestRailBase):
 
     @defects.setter
     def defects(self, values):
-        if type(values) != list:
+        if not isinstance(values, list):
             raise TestRailError('input must be a list of strings')
-        if not all(map(lambda x: type(x) == str, values)):
+        if not all(map(lambda x, : isinstance(x, str), values)):
             raise TestRailError('input must be a list of strings')
         if len(values) > 0:
             self._content['defects'] = ','.join(values)
@@ -76,7 +76,7 @@ class Result(TestRailBase):
 
     @elapsed.setter
     def elapsed(self, td):
-        if type(td) != timedelta:
+        if not isinstance(td, timedelta):
             raise TestRailError('input must be a timedelta')
         if td > timedelta(weeks=10):
             raise TestRailError('maximum elapsed time is 10 weeks')
@@ -93,7 +93,7 @@ class Result(TestRailBase):
     @status.setter
     def status(self, status_obj):
         # TODO: Should I accept string name as well?
-        if type(status_obj) != Status:
+        if not isinstance(status_obj, Status):
             raise TestRailError('input must be a Status')
         # verify id is valid
         self.api.status_with_id(status_obj.id)
@@ -106,7 +106,7 @@ class Result(TestRailBase):
 
     @test.setter
     def test(self, test_obj):
-        if type(test_obj) != Test:
+        if not isinstance(test_obj, Test):
             raise TestRailError('input must be a Test')
         # verify id is valid
         self.api.test_with_id(
@@ -119,7 +119,7 @@ class Result(TestRailBase):
 
     @version.setter
     def version(self, ver):
-        if type(ver) != str:
+        if not isinstance(ver, str):
             raise TestRailError('input must be a string')
         self._content['version'] = ver
 

--- a/testrail/section.py
+++ b/testrail/section.py
@@ -27,7 +27,7 @@ class Section(TestRailBase):
 
     @description.setter
     def description(self, value):
-        if type(value) != str:
+        if not isinstance(value, str):
             raise TestRailError('input must be a string')
         self._content['description'] = value
 
@@ -38,7 +38,7 @@ class Section(TestRailBase):
 
     @parent.setter
     def parent(self, section):
-        if type(section) != Section:
+        if not isinstance(section, Section):
             raise TestRailError('input must be a Section')
         self.api.section_with_id(section.id)  # verify section is valid
         self._content['parent_id'] = section.id
@@ -49,7 +49,7 @@ class Section(TestRailBase):
 
     @name.setter
     def name(self, value):
-        if type(value) != str:
+        if not isinstance(value, str):
             raise TestRailError('input must be a string')
         self._content['name'] = value
 
@@ -61,7 +61,7 @@ class Section(TestRailBase):
 
     @suite.setter
     def suite(self, suite_obj):
-        if type(suite_obj) != Suite:
+        if not isinstance(suite_obj, Suite):
             raise TestRailError('input must be a Suite')
         self.api.suite_with_id(suite_obj.id)  # verify suite is valid
         self._content['suite_id'] = suite_obj.id

--- a/testrail/suite.py
+++ b/testrail/suite.py
@@ -29,7 +29,7 @@ class Suite(TestRailBase):
 
     @description.setter
     def description(self, value):
-        if type(value) != str:
+        if not isinstance(value, str):
             raise TestRailError('input must be a string')
         self._content['description'] = value
 
@@ -51,7 +51,7 @@ class Suite(TestRailBase):
 
     @name.setter
     def name(self, value):
-        if type(value) != str:
+        if not isinstance(value, str):
             raise TestRailError('input must be a string')
         self._content['name'] = value
 
@@ -62,7 +62,7 @@ class Suite(TestRailBase):
 
     @project.setter
     def project(self, value):
-        if type(value) != Project:
+        if not isinstance(value, Project):
             raise TestRailError('input must be a Project')
         self.api.project_with_id(value.id)  # verify project is valid
         self._content['project_id'] = value.id


### PR DESCRIPTION
Suppose I was to subclass the Test class and add attributes specific to my environment:

```
from testrail.test import Test as TestBase

class Test(TestBase):
    def __init__(self, testrail_test):
        if not isinstance(testrail_test, TestBase):
            raise ValueError("testrail_test must be of TestRail Test type")
        super().__init__(content=testrail_test.raw_data())

    @property
    def long_running(self):
        return self._content.get("long_running", False)

    @long_running.setter
    def long_running(self, val):
        self._content['long_running'] = val
```

If I then instantiate one of these new tests and attempt to assign it to a result:
```
tests = tr_client.tests(run)
test = Test(tests[0])

result = tr_client.result()
result.test = test
```

An exception will be thrown because of the Results type checking:
```
    @test.setter
    def test(self, test_obj):
        if type(test_obj) != Test:
            raise TestRailError('input must be a Test')
```

The `type(foo) == Foo` idiom isn't capable of handling subclassing, wheres `isinstance` can:
```
    @test.setter
    def test(self, test_obj):
        if isintance(test_obj, Test):
            raise TestRailError('input must be a Test')
```

This PR reeplaces the method used for type checking (`type(foo) == Foo`) with one that allows for subclassing (`isinstance(foo, Foo)`)