### PR TITLE
Retry 503 response codes

### DIFF
--- a/testrail/helper.py
+++ b/testrail/helper.py
@@ -14,6 +14,10 @@ class TooManyRequestsError(TestRailError):
     pass
 
 
+class ServiceUnavailableError(TestRailError):
+    pass
+
+
 def methdispatch(func):
     dispatcher = singledispatch(func)
 


### PR DESCRIPTION
 - The TestRail API sometimes returns a 503 Service Unavailable status
   code
 - Add retry handling for that specific status code
 - Add delay and back off to retry attempts