### PR TITLE
Handle run by name for multi runs with same name

### DIFF
--- a/testrail/client.py
+++ b/testrail/client.py
@@ -210,6 +210,13 @@ class TestRail(object):
         return RunContainer(filter(
             lambda r: r.milestone.id == obj.id, self.runs()))
 
+    @runs.register(str)
+    @runs.register(unicode)
+    def _runs_by_name(self, name):
+        # Returns all Runs that match :name, in descending order by ID
+        runs = list(filter(lambda r: r.name.lower() == name.lower(), self.runs()))
+        return sorted(runs, key=lambda r: r.id)
+
     @methdispatch
     def run(self):
         return Run()
@@ -218,7 +225,9 @@ class TestRail(object):
     @run.register(unicode)
     @singleresult
     def _run_by_name(self, name):
-        return filter(lambda p: p.name.lower() == name.lower(), self.runs())
+        # Returns the most recently created Run that matches :name
+        runs = list(filter(lambda r: r.name.lower() == name.lower(), self.runs()))
+        return sorted(runs, key=lambda r: r.id)[:1]
 
     @run.register(int)
     @singleresult


### PR DESCRIPTION
 - Closes #106 
 - If using the single run method (client.run("Foo")), but there are multiple
   runs named "Foo", return the most recent one
 - Add new `_runs_by_name` method that will return all runs that match the name
   "Foo", in descending order by ID