### PR TITLE
Convert int to timedelta into result.elapsed

### DIFF
--- a/testrail/result.py
+++ b/testrail/result.py
@@ -79,6 +79,9 @@ class Result(TestRailBase):
         duration = self._content.get('elapsed')
         if duration is None:
             return None
+
+        if isinstance(duration, int):
+            return timedelta(seconds=duration)
         return testrail_duration_to_timedelta(duration)
 
     @elapsed.setter

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -245,6 +245,15 @@ class TestUser(unittest.TestCase):
     def test_get_elapsed_type(self):
         self.assertEqual(type(self.result.elapsed), timedelta)
 
+    def test_get_elapsed_int_type(self):
+        self.result._content['elapsed'] = 1
+        self.assertEqual(type(self.result.elapsed), timedelta)
+
+    def test_get_elapsed_int_seconds(self):
+        self.result._content['elapsed'] = 60
+        td = timedelta(seconds=60)
+        self.assertEqual(self.result.elapsed, td)
+
     def test_get_elapsed_null(self):
         self.result._content['elapsed'] = None
         self.assertEqual(self.result.elapsed, None)


### PR DESCRIPTION
If you set the value of 'elapsed' directly via setter, then call result.elapsed will be error - "TypeError: expected string or bytes-like object".