### PR TITLE
Fix: Python 3.5 don't support re.match.__getitem__

### DIFF
--- a/testrail/helper.py
+++ b/testrail/helper.py
@@ -80,5 +80,5 @@ custom_methods_re = re.compile(r'^custom_(\w+)')
 
 def custom_methods(content):
     matches = [custom_methods_re.match(method) for method in content]
-    return dict({match[1]: match[0] for match in matches if match})
+    return dict({match.group(1): match.group(0) for match in matches if match})
 


### PR DESCRIPTION
https://docs.python.org/3/library/re.html#re.match.__getitem__
It's shorthand for match.group(0) - 0 is the default if not supplied so you can omit that too.