### PR TITLE
add parameter on get result class for custom field

### DIFF
--- a/testrail/client.py
+++ b/testrail/client.py
@@ -327,6 +327,10 @@ class TestRail(object):
     @methdispatch
     def result(self):
         return Result()
+    
+    @result.register(dict)
+    def _result_for_dict(self, content):
+        return Result(content)
 
     @add.register(Result)
     def _add_result(self, obj):


### PR DESCRIPTION
using sample:
        custom_info = {'custom_version_results':'v123'}
        result = tr.result(custom_info)